### PR TITLE
URL encode FB redirect URL query string

### DIFF
--- a/Source/oauth/providers/Facebook.php
+++ b/Source/oauth/providers/Facebook.php
@@ -45,4 +45,21 @@ class Facebook extends Provider
 
         return new \League\OAuth2\Client\Provider\Facebook($config);
     }
+
+    /**
+     * Facebook refuses to accept the redirect URL if the query string is not
+     * URL encoded.
+     *
+     * @return string
+     */
+    public function getRedirectUri()
+    {
+        $url = parent::getRedirectUri();
+
+        if (preg_match('/^(.+\?p=)(.+)$/', $url, $matches)) {
+            $url = $matches[1] . urlencode($matches[2]);
+        }
+
+        return $url;
+    }
 }


### PR DESCRIPTION
Facebook refuses to accept the redirect URL if the query string is not URL-encoded. For example:

`````
// This will **not** work.
http://mysite.com/index.php?p=actions/oauth/connect

// This will work.
http://mysite.com/index.php?p=actions%2Foauth%2Fconnect
`````