### PR TITLE
simple change to allow it to work with providers that do not use the league namespace

### DIFF
--- a/helpers/OauthHelper.php
+++ b/helpers/OauthHelper.php
@@ -84,7 +84,7 @@ class OauthHelper
             $tokenArray['secret'] = $token->getSecret();
             break;
 
-            case 'League\OAuth2\Client\Token\AccessToken':
+            default:
             $tokenArray['accessToken'] = $token->getToken();
             $tokenArray['refreshToken'] = $token->getRefreshToken();
             $tokenArray['endOfLife'] = $token->getExpires();


### PR DESCRIPTION
The example in my specific use case is this one:
https://github.com/stevenmaguire/oauth2-salesforce

from the looks of it there are a lot of them like that here
https://github.com/thephpleague/oauth2-client/blob/master/README.PROVIDERS.md

Not sure if there is any danger in this change but seems to work well for us?
